### PR TITLE
[data-layer]: escape single quotes in case statements

### DIFF
--- a/packages/data-layer/src/parser/parse-expression.js
+++ b/packages/data-layer/src/parser/parse-expression.js
@@ -1,4 +1,5 @@
 import Parser from "./create-parser";
+import {escapeQuotes} from "../utils"
 
 export default function parseExpression(
   expression: string | Expression,
@@ -54,7 +55,7 @@ export default function parseExpression(
           expression.type.toUpperCase() +
           " (" +
           expression.set
-            .map(field => typeof field === "number" ? field : `'${field}'`)
+            .map(field => typeof field === "number" ? field : `'${escapeQuotes(field)}'`)
             .join(", ") +
           ")";
       } else if (

--- a/packages/data-layer/src/utils.js
+++ b/packages/data-layer/src/utils.js
@@ -42,7 +42,7 @@ export function reduceToSQL(context: GraphContext, node: DataNode): SQL {
 }
 
 export function escapeQuotes(string) {
-  if (typeof string === "string" && string.includes("'")) {
+  if (typeof string === "string") {
     return string.replace(/'/gi, "''")
   } else {
     return string

--- a/packages/data-layer/src/utils.js
+++ b/packages/data-layer/src/utils.js
@@ -40,3 +40,11 @@ export function reduceToSQL(context: GraphContext, node: DataNode): SQL {
 
   return traverse(node, identity, toSQL, initialSQL);
 }
+
+export function escapeQuotes(string) {
+  if (typeof string === "string" && string.includes("'")) {
+    return string.replace(/'/gi, "''")
+  } else {
+    return string
+  }
+}

--- a/packages/data-layer/tests/parser/parse-expression.spec.js
+++ b/packages/data-layer/tests/parser/parse-expression.spec.js
@@ -3,7 +3,7 @@ import tape from "tape";
 import parseExpression from "../../src/parser/parse-expression";
 
 tape("parseExpression", assert => {
-  assert.plan(22);
+  assert.plan(23);
 
   assert.equal(parseExpression("AVG(depdelay)"), "AVG(depdelay)");
 
@@ -225,6 +225,25 @@ assert.equal(
     }),
     "CASE WHEN recipient_party IN (SELECT recipient_party, MAX(amount) as val FROM contributions GROUP BY recipient_party LIMIT 10) THEN recipient_party END"
   );
+
+  // case statement may be constructed from a set array, single quotes should be escaped as two single quotes
+  assert.equal(
+    parseExpression({
+      type: "case",
+      cond: [
+        [
+          {
+            type: "in",
+            expr: "origin_name",
+            set: ["William B Hartsfield-Atlanta Intl", "Chicago O'Hare International", "Dallas-Fort Worth International", "Denver Int'l", "Los Angeles International"]
+          },
+          "origin_name"
+        ]
+      ],
+      else: "other"
+    }),
+    "CASE WHEN origin_name IN ('William B Hartsfield-Atlanta Intl', 'Chicago O''Hare International', 'Dallas-Fort Worth International', 'Denver Int''l', 'Los Angeles International') THEN origin_name ELSE 'other' END"
+  )
 
   assert.equal(
     parseExpression({


### PR DESCRIPTION
When constructing an `IN` statement from a set of strings, make sure to escape any single quotes within the strings to prevent a malformed SQL query.

Relates to: https://github.com/mapd/mapd-immerse/pull/4836