### PR TITLE
[data-layer] update name and bump version to 0.0.3

### DIFF
--- a/packages/data-layer/package.json
+++ b/packages/data-layer/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "mapd-data-layer",
-  "version": "0.0.4-rc.1",
+  "name": "mapd-data-layer-2",
+  "version": "0.0.3",
   "description": "SQL data-layer for the MapD frontend",
   "main": "lib/index.js",
   "module": "es/index.js",


### PR DESCRIPTION
To update mapd-data-layer I did the following:

- in root of the repo: `npm run build`
- update `packages/data-layer/package.json`'s name to `mapd-data-layer-2`
- `npm version 0.0.3`
- make sure to log into npm as `mapd-core`
- `npm publish`